### PR TITLE
update Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         submodules: recursive
@@ -37,13 +37,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         submodules: recursive
 
     - name: Checkout fred
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: 'hyphanet/fred'
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: recursive
@@ -37,13 +37,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: recursive
 
     - name: Checkout fred
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: 'hyphanet/fred'
         fetch-depth: 0
@@ -65,14 +65,16 @@ jobs:
         
     - name: Upload the windows installer as an artifact
       id: upload-artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ github.event_name != 'pull_request' }}
       with:
         path: "wininstaller-innosetup/Output/FreenetInstaller.exe"
         name: wininstaller-innosetup
+        archive: false
 
     - name: sign the windows installer
-      uses: SignPath/github-action-submit-signing-request@v0.4
+      uses: SignPath/github-action-submit-signing-request@v2
+      if: ${{ github.event_name != 'pull_request' }}
       id: sign-installer
       with:
         api-token: '${{ secrets.SIGNPATHTOKEN }}'
@@ -83,8 +85,9 @@ jobs:
         output-artifact-directory: 'wininstaller-innosetup/OutputSigned'
 
     - name: Upload the signed windows installer as an artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ github.event_name != 'pull_request' }}
       with:
         path: "wininstaller-innosetup/OutputSigned/FreenetInstaller.exe"
         name: wininstaller-innosetup-signed
+        archive: false


### PR DESCRIPTION
- actions/checkout v4 -> v7
- actions/upload-artifact v4 -> v7
- SignPath/github-action-submit-signing-request v0.4 -> v2
- Use Direct Uploads feature of upload-artifact v7 https://github.com/actions/upload-artifact/pull/764
- Avoid signing request on pull requests